### PR TITLE
Integrate token-based admin session

### DIFF
--- a/Admin.html
+++ b/Admin.html
@@ -138,7 +138,8 @@ function showTab(key){
 function doLogout(){
   google.script.run.withSuccessHandler(_=>{
     TOKEN=null; CURRENT_USER=null; CURRENT_ROLE='VIEWER';
-    // връщаме към началната страница
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
     const u=new URL(location.href); u.searchParams.delete('page'); location.href=u.toString();
   }).logout(TOKEN, CURRENT_USER?.email||'');
 }
@@ -254,11 +255,20 @@ function loadLogs(page){
 
 /* Инициализация – взимаме данни за текущата сесия от логин-а (кеша) */
 window.addEventListener('load', ()=>{
+  const token = localStorage.getItem('token');
+  if(!token){
+    alert('Сесията е изтекла.');
+    const u=new URL(location.href); u.searchParams.delete('page'); location.href=u.toString();
+    return;
+  }
   google.script.run.withSuccessHandler(res=>{
     TOKEN = res.token; CURRENT_USER = res.user||{}; CURRENT_ROLE = CURRENT_USER.role||'VIEWER';
     $('who').textContent = `${CURRENT_USER.name||''} • ${CURRENT_USER.email||''} • ${CURRENT_ROLE}`;
     applyRoleGuards(); showTab('dash');
-  }).resumeSession(); // виж AdminAuth.gs
+  }).withFailureHandler(err=>{
+    alert(err.message||err);
+    const u=new URL(location.href); u.searchParams.delete('page'); location.href=u.toString();
+  }).resumeSessionWithToken(token);
 });
 </script>
 </body>

--- a/AdminApi.gs
+++ b/AdminApi.gs
@@ -5,7 +5,7 @@
 function listUsers(token) {
   ensureAdminSheets_();
   const auth = assertAuth_(token);
-  const sh = SS.getSheetByName('Users');
+  const sh = SS_().getSheetByName('Users');
   const values = sh.getDataRange().getValues();
   if (values.length < 2) return [];
   values.shift();
@@ -23,7 +23,7 @@ function upsertUser(token,row,name,email,passwordOrEmpty,role) {
   const auth = assertAuth_(token);
   if (auth.role !== 'ADMIN') throw new Error('Нямате права.');
   if (!name || !email) throw new Error('Име и email са задължителни.');
-  const sh = SS.getSheetByName('Users');
+  const sh = SS_().getSheetByName('Users');
   let passHash = '';
   if (passwordOrEmpty) passHash = _sha256_(passwordOrEmpty);
   const data = [name, email, passHash, role || 'VIEWER'];
@@ -41,7 +41,7 @@ function deleteUser(token,row,emailForLog) {
   ensureAdminSheets_();
   const auth = assertAuth_(token);
   if (auth.role !== 'ADMIN') throw new Error('Нямате права.');
-  const sh = SS.getSheetByName('Users');
+  const sh = SS_().getSheetByName('Users');
   if (!row || row < 2) throw new Error('Невалиден ред.');
   sh.deleteRow(row);
   log_(auth.email,'USER_DELETE',`row=${row}, email=${emailForLog||''}`);
@@ -51,7 +51,7 @@ function deleteUser(token,row,emailForLog) {
 function listPanels(token) {
   ensureAdminSheets_();
   const auth = assertAuth_(token);
-  const sh = SS.getSheetByName('Panels');
+  const sh = SS_().getSheetByName('Panels');
   const values = sh.getDataRange().getValues();
   if (values.length < 2) return [];
   values.shift();
@@ -67,7 +67,7 @@ function setPanelVisibility(token,row,visible) {
   ensureAdminSheets_();
   const auth = assertAuth_(token);
   if (auth.role === 'VIEWER') throw new Error('Нямате права.');
-  const sh = SS.getSheetByName('Panels');
+  const sh = SS_().getSheetByName('Panels');
   if (!row || row < 2) throw new Error('Невалиден ред.');
   sh.getRange(row,3).setValue(!!visible);
   const key = sh.getRange(row,1).getValue();
@@ -121,7 +121,7 @@ function updateTransaction(token,row,changes) {
 function getLogs(token,page,pageSize) {
   ensureAdminSheets_();
   const auth = assertAuth_(token);
-  const sh = SS.getSheetByName('AuditLog');
+  const sh = SS_().getSheetByName('AuditLog');
   const values = sh.getDataRange().getValues();
   if (values.length < 2) return { rows: [], total: 0, page: 1, pageSize: 50 };
   const rows = values.slice(1).map(r=>({ ts:r[0], email:r[1], action:r[2], details:r[3], ip:r[4], ua:r[5] })).reverse();
@@ -129,4 +129,5 @@ function getLogs(token,page,pageSize) {
   const ps = Math.max(1, parseInt(pageSize||50,10));
   const p = Math.max(1, parseInt(page||1,10));
   const start = (p-1)*ps;
-  return { rows: rows.slice(start,start+ps), total, page:p,
+  return { rows: rows.slice(start,start+ps), total, page:p, pageSize:ps };
+}

--- a/AdminAuth.gs
+++ b/AdminAuth.gs
@@ -17,7 +17,7 @@ function ensureAdminSheets_() {
   // Users (Name,Email,PasswordHash,Role)
   let shU = SS_().getSheetByName('Users');
   if (!shU) {
-    shU = SS.insertSheet('Users');
+    shU = SS_().insertSheet('Users');
     shU.getRange(1,1,1,4).setValues([['Name','Email','PasswordHash','Role']]);
     shU.setFrozenRows(1);
   } else if (shU.getLastRow() === 0) {
@@ -27,7 +27,7 @@ function ensureAdminSheets_() {
   // Panels (PanelKey,Title,Visible)
   let shP = SS_().getSheetByName('Panels');
   if (!shP) {
-    shP = SS.insertSheet('Panels');
+    shP = SS_().insertSheet('Panels');
     shP.getRange(1,1,1,3).setValues([['PanelKey','Title','Visible']]);
     shP.setFrozenRows(1);
     shP.getRange(2,1,5,3).setValues([
@@ -44,7 +44,7 @@ function ensureAdminSheets_() {
   // AuditLog (Timestamp,Email,Action,Details,IP,UserAgent)
   let shL = SS_().getSheetByName('AuditLog');
   if (!shL) {
-    shL = SS.insertSheet('AuditLog');
+    shL = SS_().insertSheet('AuditLog');
     shL.getRange(1,1,1,6).setValues([['Timestamp','Email','Action','Details','IP','UserAgent']]);
     shL.setFrozenRows(1);
   } else if (shL.getLastRow() === 0) {

--- a/Landing.html
+++ b/Landing.html
@@ -337,38 +337,30 @@
         }
         
         if (isValid) {
-          // Показване на съобщение за зареждане
           loginBtn.textContent = 'Вход...';
           loginBtn.disabled = true;
-          
-          // Симулация на заявка към сървъра
-          setTimeout(function() {
-            // В реална ситуация тук ще имаме заявка към Google Script
-            alert('Входът е успешен! Пренасочване към основното приложение...');
-            // В реална ситуация ще пренасочим към приложението
-            // google.script.run.withSuccessHandler(...).login(...);
-            
-            // Връщане на бутона в нормално състояние
-            loginBtn.textContent = 'Влез в системата';
-            loginBtn.disabled = false;
-          }, 1500);
+          google.script.run
+            .withSuccessHandler(res => {
+              localStorage.setItem('token', res.token);
+              localStorage.setItem('user', JSON.stringify(res.user || {}));
+              window.location.href = '?page=admin';
+            })
+            .withFailureHandler(err => {
+              alert(err.message || err);
+              loginBtn.textContent = 'Влез в системата';
+              loginBtn.disabled = false;
+            })
+            .login(emailInput.value.trim(), passwordInput.value);
         }
       });
-      
       // Бутон за админ панел
       adminBtn.addEventListener('click', function() {
-        adminBtn.textContent = 'Отваряне...';
-        adminBtn.disabled = true;
-        
-        // Симулация на зареждане
-        setTimeout(function() {
-          alert('Пренасочване към админ панела...');
-          // В реална ситуация: google.script.run.showAdminPanel_();
-          
-          // Връщане на бутона в нормално състояние
-          adminBtn.textContent = 'Вход в админ панела';
-          adminBtn.disabled = false;
-        }, 1000);
+        const token = localStorage.getItem('token');
+        if (!token) {
+          alert('Моля, влез първо.');
+          return;
+        }
+        window.location.href = '?page=admin';
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- Replace direct spreadsheet references with helper wrapper in auth and API code
- Hook landing page login to server-side and redirect with stored token
- Resume admin sessions from local storage and clear token on logout

## Testing
- `node --check --input-type=module < AdminAuth.gs`
- `node --check --input-type=module < AdminApi.gs`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6829063608324a7aca657778c45ae