### PR TITLE
Evaluate templates in doGet to return HTML

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -55,17 +55,20 @@ function doGet(e){
   ensureSheets_();
   const page = (e && e.parameter && e.parameter.page) ? String(e.parameter.page).toLowerCase() : '';
   if (page === 'app') {
-    return HtmlService.createHtmlOutputFromFile('Index')
+    return HtmlService.createTemplateFromFile('Index')
+      .evaluate()
       .setTitle('Отчитане на магазин')
       .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
   }
   if (page === 'admin') {
-    return HtmlService.createHtmlOutputFromFile('Admin')
+    return HtmlService.createTemplateFromFile('Admin')
+      .evaluate()
       .setTitle('Админ панел')
       .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
   }
   // default: Landing
-  return HtmlService.createHtmlOutputFromFile('Landing')
+  return HtmlService.createTemplateFromFile('Landing')
+    .evaluate()
     .setTitle('Начало')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }


### PR DESCRIPTION
## Summary
- Ensure doGet evaluates HTML templates so web app pages render correctly

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c688717dec832497a9c970321cda4c